### PR TITLE
Add an example notebook for model metadata service

### DIFF
--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,0 +1,2 @@
+#Ipython Notebook
+.ipynb_checkpoints

--- a/examples/metadata_demo.ipynb
+++ b/examples/metadata_demo.ipynb
@@ -1,0 +1,335 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Model Metadata API Demo"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The Model Metadata API is still in developement. This demo showcases some of the functionality of the new API."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Api Configuration"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from seldon_deploy_sdk.rest import ApiException\n",
+    "\n",
+    "from seldon_deploy_sdk import V1Model, ModelMetadataServiceApi, Configuration, ApiClient\n",
+    "from seldon_deploy_sdk.auth import OIDCAuthenticator\n",
+    "from pprint import pprint\n",
+    "\n",
+    "config = Configuration()\n",
+    "config.host = \"http://localhost:8080\"\n",
+    "# auth if needed\n",
+    "# config.oidc_server = \"http://localhost:8080/auth/realms/deploy-realm\"\n",
+    "# config.oidc_client_id = \"sd-cli\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# auth = OIDCAuthenticator(config)\n",
+    "api_client = ApiClient(config)\n",
+    "# config.access_token = auth.authenticate(\"admin@seldon.io\", \"12341234\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "api_instance = ModelMetadataServiceApi(api_client)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create a model metadata entry"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = V1Model(\n",
+    "    uri=\"gs://test-model-alpha-v1.0.0\",\n",
+    "    name=\"alpha\",\n",
+    "    version=\"v1.0.0\",\n",
+    "    implementation=\"XGBOOST\",\n",
+    "    task_type=\"regression\",\n",
+    "    tags={\n",
+    "        \"source\": \"https://github.com/some-test-model-alpha-repo\",\n",
+    "        \"an arbitrary tag\": \"true\",\n",
+    "    },\n",
+    ")\n",
+    "try:\n",
+    "    # Create a Model Metadata entry.\n",
+    "    api_response = api_instance.model_metadata_service_create_model_metadata(model)\n",
+    "    pprint(api_response)\n",
+    "except ApiException as e:\n",
+    "    print(\n",
+    "        \"Exception when calling ModelMetadataServiceApi->model_metadata_service_create_model_metadata: %s\\n\"\n",
+    "        % e\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create multiple metadata entries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "models = [\n",
+    "    #     Same model different versions\n",
+    "    {\n",
+    "        \"uri\": \"gs://test-model-beta-v1.0.0\",\n",
+    "        \"name\": \"beta\",\n",
+    "        \"version\": \"v1.0.0\",\n",
+    "        \"implementation\": \"SKLEARN\",\n",
+    "        \"task_type\": \"classification\",\n",
+    "        \"tags\": {\"author\": \"Jon\"},\n",
+    "    },\n",
+    "    {\n",
+    "        \"uri\": \"gs://test-model-beta-v2.0.0\",\n",
+    "        \"name\": \"beta\",\n",
+    "        \"version\": \"v2.0.0\",\n",
+    "        \"implementation\": \"SKLEARN\",\n",
+    "        \"task_type\": \"classification\",\n",
+    "        \"tags\": {\"author\": \"Bob\"},\n",
+    "    },\n",
+    "    {\n",
+    "        \"uri\": \"gs://test-model-beta-v3.0.0\",\n",
+    "        \"name\": \"beta\",\n",
+    "        \"version\": \"v3.0.0\",\n",
+    "        \"implementation\": \"SKLEARN\",\n",
+    "        \"task_type\": \"classification\",\n",
+    "        \"tags\": {\"author\": \"Bob\"},\n",
+    "    },\n",
+    "]\n",
+    "\n",
+    "for model in models:\n",
+    "    body = V1Model(**model)\n",
+    "    try:\n",
+    "        # Create a Model Metadata entry.\n",
+    "        api_response = api_instance.model_metadata_service_create_model_metadata(body)\n",
+    "        pprint(api_response)\n",
+    "    except ApiException as e:\n",
+    "        print(\n",
+    "            \"Exception when calling ModelMetadataServiceApi->model_metadata_service_create_model_metadata: %s\\n\"\n",
+    "            % e\n",
+    "        )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## List all model metadata entries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    # List Model Metadata entries.\n",
+    "    api_response = api_instance.model_metadata_service_list_model_metadata()\n",
+    "    pprint(api_response)\n",
+    "except ApiException as e:\n",
+    "    print(\n",
+    "        \"Exception when calling ModelMetadataServiceApi->model_metadata_service_list_model_metadata: %s\\n\"\n",
+    "        % e\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Filter model metadata entries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# uri = 'uri_example' # str |  (optional)\n",
+    "# name = 'name_example' # str |  (optional)\n",
+    "# version = 'version_example' # str |  (optional)\n",
+    "# implementation = 'implementation_example' # str |  (optional)\n",
+    "# task_type = 'task_type_example' # str |  (optional)\n",
+    "# model_type = 'model_type_example' # str |  (optional)\n",
+    "\n",
+    "try:\n",
+    "    # List Model Metadata entries.\n",
+    "    api_response = api_instance.model_metadata_service_list_model_metadata(name=\"beta\")\n",
+    "    print(\"Filter by name=beta\")\n",
+    "    pprint(api_response)\n",
+    "except ApiException as e:\n",
+    "    print(\n",
+    "        \"Exception when calling ModelMetadataServiceApi->model_metadata_service_list_model_metadata: %s\\n\"\n",
+    "        % e\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Modify a metadata entry"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    # List Model Metadata entries.\n",
+    "    api_response = api_instance.model_metadata_service_list_model_metadata(uri=\"gs://test-model-alpha-v1.0.0\")\n",
+    "    print(\"Before update:\")\n",
+    "    pprint(api_response)\n",
+    "except ApiException as e:\n",
+    "    print(\n",
+    "        \"Exception when calling ModelMetadataServiceApi->model_metadata_service_list_model_metadata: %s\\n\"\n",
+    "        % e\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "model = V1Model(\n",
+    "    uri=\"gs://test-model-alpha-v1.0.0\",\n",
+    "    name=\"alpha\",\n",
+    "    version=\"v1.0.0\",\n",
+    "    implementation=\"XGBOOST\",\n",
+    "    task_type=\"regression\",\n",
+    "    tags={\n",
+    "        \"source\": \"https://github.com/some-other-repo\",\n",
+    "        \"an arbitrary tag\": \"true\",\n",
+    "        \"an additional tag\": \"123\",\n",
+    "    },\n",
+    ")\n",
+    "try:\n",
+    "    # Update a Model Metadata entry.\n",
+    "    api_response = api_instance.model_metadata_service_update_model_metadata(model)\n",
+    "    pprint(api_response)\n",
+    "except ApiException as e:\n",
+    "    print(\"Exception when calling ModelMetadataServiceApi->model_metadata_service_update_model_metadata: %s\\n\" % e)\n",
+    "    \n",
+    "try:\n",
+    "    # List Model Metadata entries.\n",
+    "    api_response = api_instance.model_metadata_service_list_model_metadata(uri=\"gs://test-model-alpha-v1.0.0\")\n",
+    "    print(\"After update:\")\n",
+    "    pprint(api_response)\n",
+    "except ApiException as e:\n",
+    "    print(\n",
+    "        \"Exception when calling ModelMetadataServiceApi->model_metadata_service_list_model_metadata: %s\\n\"\n",
+    "        % e\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Get runtime information for a model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    # List Runtime Metadata for all deployments associated with a model.\n",
+    "    api_response = api_instance.model_metadata_service_list_runtime_metadata_for_model(model_uri=\"gs://kfserving-samples/models/sklearn/iris\", deployment_status=\"Running\")\n",
+    "    pprint(api_response)\n",
+    "except ApiException as e:\n",
+    "    print(\"Exception when calling ModelMetadataServiceApi->model_metadata_service_list_runtime_metadata_for_model: %s\\n\" % e)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Get model information for a deployment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    # List Runtime Metadata for all deployments associated with a model.\n",
+    "    api_response = api_instance.model_metadata_service_list_runtime_metadata_for_model(deployment_name=\"iris\", deployment_namespace=\"seldon\")\n",
+    "    pprint(api_response)\n",
+    "except ApiException as e:\n",
+    "    print(\"Exception when calling ModelMetadataServiceApi->model_metadata_service_list_runtime_metadata_for_model: %s\\n\" % e)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
An notebook showing how the sdk can be used to interact with Seldon Deploy's Metadata Service. It expect a Seldon Deploy instance port forwarded to `localhost:8080`.
The demo goes over the basic functionality of creating, filtering, updating model metadata. It also covers interacting with runtime metadata by listing deployment associated with a model and models associated with a deployment.