### PR TITLE
Use enum and abstract base class in auth package

### DIFF
--- a/python/seldon_deploy_sdk/auth/base.py
+++ b/python/seldon_deploy_sdk/auth/base.py
@@ -31,7 +31,7 @@ def _soft_deprecate(
             elif not self._config.username:
                 raise ValueError(
                     "config.username is required for "
-                    f"{AuthMethod.PASSWORD_GRANT.name}"
+                    f"{AuthMethod.PASSWORD_GRANT.value}"
                 )
 
             if password:
@@ -39,7 +39,7 @@ def _soft_deprecate(
             elif not self._config.password:
                 raise ValueError(
                     "config.password is required for "
-                    f"{AuthMethod.PASSWORD_GRANT.name}"
+                    f"{AuthMethod.PASSWORD_GRANT.value}"
                 )
 
         return authenticate(self, username, password)
@@ -47,10 +47,10 @@ def _soft_deprecate(
     return _f
 
 
-class AuthMethod(Enum):
-    PASSWORD_GRANT = auto()
-    CLIENT_CREDENTIALS = auto()
-    AUTH_CODE = auto()
+class AuthMethod(str, Enum):
+    PASSWORD_GRANT = 'password_grant'
+    CLIENT_CREDENTIALS = 'client_credentials'
+    AUTH_CODE = 'auth_code'
 
 
 class Authenticator:
@@ -62,11 +62,11 @@ class Authenticator:
         if self._config.auth_method == AuthMethod.PASSWORD_GRANT:
             if not self._config.username:
                 _deprecation_warning("username")
-                #  raise ValueError(f"config.username is required for {AuthMethod.PASSWORD_GRANT.name}")
+                #  raise ValueError(f"config.username is required for {AuthMethod.PASSWORD_GRANT.value}")
 
             if not self._config.password:
                 _deprecation_warning("password")
-                #  raise ValueError(f"config.username is required for {AuthMethod.PASSWORD_GRANT.name}")
+                #  raise ValueError(f"config.username is required for {AuthMethod.PASSWORD_GRANT.value}")
 
     def authenticate(self, username: str = None, password: str = None) -> str:
         raise NotImplementedError("Authenticate method not implemented")

--- a/python/seldon_deploy_sdk/auth/base.py
+++ b/python/seldon_deploy_sdk/auth/base.py
@@ -1,5 +1,5 @@
 import logging
-from enum import auto, Enum
+from enum import Enum
 from functools import wraps
 
 from urllib.parse import urlparse

--- a/python/seldon_deploy_sdk/auth/base.py
+++ b/python/seldon_deploy_sdk/auth/base.py
@@ -48,6 +48,12 @@ def _soft_deprecate(
     return _f
 
 
+def _raise_auth_method_not_supported(auth_method: str):
+    raise NotImplementedError(
+        f"Auth method '{auth_method}' not specified or not supported"
+    )
+
+
 class AuthMethod(str, Enum):
     PASSWORD_GRANT = 'password_grant'
     CLIENT_CREDENTIALS = 'client_credentials'

--- a/python/seldon_deploy_sdk/auth/base.py
+++ b/python/seldon_deploy_sdk/auth/base.py
@@ -1,4 +1,5 @@
 import logging
+from abc import ABC, abstractmethod
 from enum import Enum
 from functools import wraps
 
@@ -53,7 +54,7 @@ class AuthMethod(str, Enum):
     AUTH_CODE = 'auth_code'
 
 
-class Authenticator:
+class Authenticator(ABC):
     def __init__(self, config: Configuration):
         self._server = config.host
         self._host = self._get_host()
@@ -68,9 +69,10 @@ class Authenticator:
                 _deprecation_warning("password")
                 #  raise ValueError(f"config.username is required for {AuthMethod.PASSWORD_GRANT.value}")
 
-    def authenticate(self, username: str = None, password: str = None) -> str:
-        raise NotImplementedError("Authenticate method not implemented")
-
     def _get_host(self) -> str:
         url = urlparse(self._server)
         return f"{url.scheme}://{url.netloc}"
+
+    @abstractmethod
+    def authenticate(self, username: str = None, password: str = None) -> str:
+        pass

--- a/python/seldon_deploy_sdk/auth/base.py
+++ b/python/seldon_deploy_sdk/auth/base.py
@@ -1,4 +1,5 @@
 import logging
+from enum import auto, Enum
 from functools import wraps
 
 from urllib.parse import urlparse
@@ -24,20 +25,32 @@ def _soft_deprecate(
 ):
     @wraps(authenticate)
     def _f(self, username: str = None, password: str = None) -> str:
-        if self._config.auth_method == "password_grant":
+        if self._config.auth_method == AuthMethod.PASSWORD_GRANT:
             if username:
                 _deprecation_warning("username")
             elif not self._config.username:
-                raise ValueError("config.username is required for password_grant")
+                raise ValueError(
+                    "config.username is required for "
+                    f"{AuthMethod.PASSWORD_GRANT.name}"
+                )
 
             if password:
                 _deprecation_warning("password")
             elif not self._config.password:
-                raise ValueError("config.password is required for password_grant")
+                raise ValueError(
+                    "config.password is required for "
+                    f"{AuthMethod.PASSWORD_GRANT.name}"
+                )
 
         return authenticate(self, username, password)
 
     return _f
+
+
+class AuthMethod(Enum):
+    PASSWORD_GRANT = auto()
+    CLIENT_CREDENTIALS = auto()
+    AUTH_CODE = auto()
 
 
 class Authenticator:
@@ -46,14 +59,14 @@ class Authenticator:
         self._host = self._get_host()
         self._config = config
 
-        if self._config.auth_method == "password_grant":
+        if self._config.auth_method == AuthMethod.PASSWORD_GRANT:
             if not self._config.username:
                 _deprecation_warning("username")
-                #  raise ValueError("config.username is required for password_grant")
+                #  raise ValueError(f"config.username is required for {AuthMethod.PASSWORD_GRANT.name}")
 
             if not self._config.password:
                 _deprecation_warning("password")
-                #  raise ValueError("config.username is required for password_grant")
+                #  raise ValueError(f"config.username is required for {AuthMethod.PASSWORD_GRANT.name}")
 
     def authenticate(self, username: str = None, password: str = None) -> str:
         raise NotImplementedError("Authenticate method not implemented")

--- a/python/seldon_deploy_sdk/auth/openid.py
+++ b/python/seldon_deploy_sdk/auth/openid.py
@@ -29,7 +29,7 @@ class OIDCAuthenticator(Authenticator):
             if not config.oidc_client_secret:
                 raise ValueError(
                     "config.oidc_client_secret is required for "
-                    f"{AuthMethod.CLIENT_CREDENTIALS.name}"
+                    f"{AuthMethod.CLIENT_CREDENTIALS.value}"
                 )
 
         access_token_params = None
@@ -59,7 +59,7 @@ class OIDCAuthenticator(Authenticator):
         elif self._config.auth_method == AuthMethod.CLIENT_CREDENTIALS:
             token = self._app.fetch_access_token(
                 scope=self._config.scope,
-                grant_type=AuthMethod.CLIENT_CREDENTIALS,
+                grant_type=AuthMethod.CLIENT_CREDENTIALS.value,
             )
             return token[IdTokenField]
 

--- a/python/seldon_deploy_sdk/auth/openid.py
+++ b/python/seldon_deploy_sdk/auth/openid.py
@@ -5,7 +5,12 @@ from authlib.integrations.requests_client import OAuth2Session
 
 from seldon_deploy_sdk.configuration import Configuration
 
-from .base import Authenticator, AuthMethod, _soft_deprecate
+from .base import (
+    Authenticator,
+    AuthMethod,
+    _raise_auth_method_not_supported,
+    _soft_deprecate,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -63,4 +68,4 @@ class OIDCAuthenticator(Authenticator):
             )
             return token[IdTokenField]
 
-        raise NotImplementedError("Auth method not specified or not supported")
+        _raise_auth_method_not_supported(self._config.auth_method)

--- a/python/seldon_deploy_sdk/auth/openid.py
+++ b/python/seldon_deploy_sdk/auth/openid.py
@@ -5,7 +5,7 @@ from authlib.integrations.requests_client import OAuth2Session
 
 from seldon_deploy_sdk.configuration import Configuration
 
-from .base import Authenticator, _soft_deprecate
+from .base import Authenticator, AuthMethod, _soft_deprecate
 
 logger = logging.getLogger(__name__)
 
@@ -25,10 +25,11 @@ class OIDCAuthenticator(Authenticator):
         if config.oidc_client_id is None:
             raise ValueError("config.oidc_client_id is required")
 
-        if config.auth_method == "client_credentials":
+        if config.auth_method == AuthMethod.CLIENT_CREDENTIALS:
             if not config.oidc_client_secret:
                 raise ValueError(
-                    "config.oidc_client_secret is required for client_credentials"
+                    "config.oidc_client_secret is required for "
+                    f"{AuthMethod.CLIENT_CREDENTIALS.name}"
                 )
 
         access_token_params = None
@@ -48,16 +49,17 @@ class OIDCAuthenticator(Authenticator):
 
     @_soft_deprecate  # type: ignore
     def authenticate(self, username: str = None, password: str = None) -> str:
-        if self._config.auth_method == "password_grant":
+        if self._config.auth_method == AuthMethod.PASSWORD_GRANT:
             token = self._app.fetch_access_token(
                 username=username or self._config.username,
                 password=password or self._config.password,
                 scope=self._config.scope,
             )
             return token[IdTokenField]
-        elif self._config.auth_method == "client_credentials":
+        elif self._config.auth_method == AuthMethod.CLIENT_CREDENTIALS:
             token = self._app.fetch_access_token(
-                scope=self._config.scope, grant_type="client_credentials"
+                scope=self._config.scope,
+                grant_type=AuthMethod.CLIENT_CREDENTIALS,
             )
             return token[IdTokenField]
 

--- a/python/seldon_deploy_sdk/auth/session.py
+++ b/python/seldon_deploy_sdk/auth/session.py
@@ -6,7 +6,7 @@ from seldon_deploy_sdk.rest import RESTClientObject
 from .base import (
     Authenticator,
     AuthMethod,
-    _auth_method_not_supported,
+    _raise_auth_method_not_supported,
     _soft_deprecate,
 )
 
@@ -32,7 +32,7 @@ class SessionAuthenticator(Authenticator):
             )
             return session_cookie
 
-        _auth_method_not_supported(self._config.auth_method)
+        _raise_auth_method_not_supported(self._config.auth_method)
 
     def _get_auth_path(self) -> str:
         # Send unauthenticated request

--- a/python/seldon_deploy_sdk/auth/session.py
+++ b/python/seldon_deploy_sdk/auth/session.py
@@ -3,7 +3,7 @@ from urllib3 import Retry
 from seldon_deploy_sdk.configuration import Configuration
 from seldon_deploy_sdk.rest import RESTClientObject
 
-from .base import Authenticator, _soft_deprecate
+from .base import Authenticator, AuthMethod, _soft_deprecate
 
 
 class SessionAuthenticator(Authenticator):
@@ -19,7 +19,7 @@ class SessionAuthenticator(Authenticator):
     @_soft_deprecate  # type: ignore
     def authenticate(self, username: str = None, password: str = None) -> str:
         auth_path = self._get_auth_path()
-        if self._config.auth_method == "password_grant":
+        if self._config.auth_method == AuthMethod.PASSWORD_GRANT:
             session_cookie = self._submit_auth(
                 auth_path,
                 username or self._config.username,

--- a/python/seldon_deploy_sdk/auth/session.py
+++ b/python/seldon_deploy_sdk/auth/session.py
@@ -3,7 +3,12 @@ from urllib3 import Retry
 from seldon_deploy_sdk.configuration import Configuration
 from seldon_deploy_sdk.rest import RESTClientObject
 
-from .base import Authenticator, AuthMethod, _soft_deprecate
+from .base import (
+    Authenticator,
+    AuthMethod,
+    _auth_method_not_supported,
+    _soft_deprecate,
+)
 
 
 class SessionAuthenticator(Authenticator):
@@ -27,7 +32,7 @@ class SessionAuthenticator(Authenticator):
             )
             return session_cookie
 
-        raise NotImplementedError("Auth method not specified or not supported")
+        _auth_method_not_supported(self._config.auth_method)
 
     def _get_auth_path(self) -> str:
         # Send unauthenticated request

--- a/templates/python/auth/base.py
+++ b/templates/python/auth/base.py
@@ -1,4 +1,6 @@
 import logging
+from abc import ABC, abstractmethod
+from enum import Enum
 from functools import wraps
 
 from urllib.parse import urlparse
@@ -24,40 +26,59 @@ def _soft_deprecate(
 ):
     @wraps(authenticate)
     def _f(self, username: str = None, password: str = None) -> str:
-        if self._config.auth_method == "password_grant":
+        if self._config.auth_method == AuthMethod.PASSWORD_GRANT:
             if username:
                 _deprecation_warning("username")
             elif not self._config.username:
-                raise ValueError("config.username is required for password_grant")
+                raise ValueError(
+                    "config.username is required for "
+                    f"{AuthMethod.PASSWORD_GRANT.value}"
+                )
 
             if password:
                 _deprecation_warning("password")
             elif not self._config.password:
-                raise ValueError("config.password is required for password_grant")
+                raise ValueError(
+                    "config.password is required for "
+                    f"{AuthMethod.PASSWORD_GRANT.value}"
+                )
 
         return authenticate(self, username, password)
 
     return _f
 
 
-class Authenticator:
+def _raise_auth_method_not_supported(auth_method: str):
+    raise NotImplementedError(
+        f"Auth method '{auth_method}' not specified or not supported"
+    )
+
+
+class AuthMethod(str, Enum):
+    PASSWORD_GRANT = 'password_grant'
+    CLIENT_CREDENTIALS = 'client_credentials'
+    AUTH_CODE = 'auth_code'
+
+
+class Authenticator(ABC):
     def __init__(self, config: Configuration):
         self._server = config.host
         self._host = self._get_host()
         self._config = config
 
-        if self._config.auth_method == "password_grant":
+        if self._config.auth_method == AuthMethod.PASSWORD_GRANT:
             if not self._config.username:
                 _deprecation_warning("username")
-                #  raise ValueError("config.username is required for password_grant")
+                #  raise ValueError(f"config.username is required for {AuthMethod.PASSWORD_GRANT.value}")
 
             if not self._config.password:
                 _deprecation_warning("password")
-                #  raise ValueError("config.username is required for password_grant")
-
-    def authenticate(self, username: str = None, password: str = None) -> str:
-        raise NotImplementedError("Authenticate method not implemented")
+                #  raise ValueError(f"config.username is required for {AuthMethod.PASSWORD_GRANT.value}")
 
     def _get_host(self) -> str:
         url = urlparse(self._server)
         return f"{url.scheme}://{url.netloc}"
+
+    @abstractmethod
+    def authenticate(self, username: str = None, password: str = None) -> str:
+        pass

--- a/templates/python/auth/openid.py
+++ b/templates/python/auth/openid.py
@@ -5,7 +5,12 @@ from authlib.integrations.requests_client import OAuth2Session
 
 from seldon_deploy_sdk.configuration import Configuration
 
-from .base import Authenticator, _soft_deprecate
+from .base import (
+    Authenticator,
+    AuthMethod,
+    _raise_auth_method_not_supported,
+    _soft_deprecate,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -25,10 +30,11 @@ class OIDCAuthenticator(Authenticator):
         if config.oidc_client_id is None:
             raise ValueError("config.oidc_client_id is required")
 
-        if config.auth_method == "client_credentials":
+        if config.auth_method == AuthMethod.CLIENT_CREDENTIALS:
             if not config.oidc_client_secret:
                 raise ValueError(
-                    "config.oidc_client_secret is required for client_credentials"
+                    "config.oidc_client_secret is required for "
+                    f"{AuthMethod.CLIENT_CREDENTIALS.value}"
                 )
 
         access_token_params = None
@@ -48,17 +54,17 @@ class OIDCAuthenticator(Authenticator):
 
     @_soft_deprecate  # type: ignore
     def authenticate(self, username: str = None, password: str = None) -> str:
-        if self._config.auth_method == "password_grant":
+        if self._config.auth_method == AuthMethod.PASSWORD_GRANT:
             token = self._app.fetch_access_token(
                 username=username or self._config.username,
                 password=password or self._config.password,
                 scope=self._config.scope,
             )
             return token[IdTokenField]
-        elif self._config.auth_method == "client_credentials":
+        elif self._config.auth_method == AuthMethod.CLIENT_CREDENTIALS:
             token = self._app.fetch_access_token(
-                scope=self._config.scope, grant_type="client_credentials"
+                scope=self._config.scope,
+                grant_type=AuthMethod.CLIENT_CREDENTIALS.value,
             )
             return token[IdTokenField]
-
-        raise NotImplementedError("Auth method not specified or not supported")
+        _raise_auth_method_not_supported(self._config.auth_method)

--- a/templates/python/auth/session.py
+++ b/templates/python/auth/session.py
@@ -3,7 +3,12 @@ from urllib3 import Retry
 from seldon_deploy_sdk.configuration import Configuration
 from seldon_deploy_sdk.rest import RESTClientObject
 
-from .base import Authenticator, _soft_deprecate
+from .base import (
+    Authenticator,
+    AuthMethod,
+    _raise_auth_method_not_supported,
+    _soft_deprecate,
+)
 
 
 class SessionAuthenticator(Authenticator):
@@ -19,7 +24,7 @@ class SessionAuthenticator(Authenticator):
     @_soft_deprecate  # type: ignore
     def authenticate(self, username: str = None, password: str = None) -> str:
         auth_path = self._get_auth_path()
-        if self._config.auth_method == "password_grant":
+        if self._config.auth_method == AuthMethod.PASSWORD_GRANT:
             session_cookie = self._submit_auth(
                 auth_path,
                 username or self._config.username,
@@ -27,7 +32,7 @@ class SessionAuthenticator(Authenticator):
             )
             return session_cookie
 
-        raise NotImplementedError("Auth method not specified or not supported")
+        _raise_auth_method_not_supported(self._config.auth_method)
 
     def _get_auth_path(self) -> str:
         # Send unauthenticated request

--- a/templates/python/requirements.mustache
+++ b/templates/python/requirements.mustache
@@ -1,7 +1,7 @@
+authlib <= 0.16.0
 certifi >= 14.05.14
-six >= 1.10
 python_dateutil >= 2.5.3
-setuptools >= 21.0.0
-urllib3 >= 1.15.1
-Authlib <= 0.16.0
 requests >= 2.0.0, <= 3.0.0
+setuptools >= 21.0.0
+six >= 1.10
+urllib3 >= 1.15.1

--- a/templates/python/requirements.mustache
+++ b/templates/python/requirements.mustache
@@ -4,3 +4,4 @@ python_dateutil >= 2.5.3
 setuptools >= 21.0.0
 urllib3 >= 1.15.1
 Authlib <= 0.16.0
+requests >= 2.0.0, <= 3.0.0


### PR DESCRIPTION
These changes bump the required Python version to 3.6 (3.4 for `Enum`, 3.6 for f-strings), which @adriangonz has indicated is the minimum version being targeted in any case.

Using an enum internally clarifies the permitted auth types better than a collection of string constants scattered about 3 or 4 files (at least) and protects against typos in internal code.
This goes a little way towards easing the introduction of a new auth method in [DPL-293](https://seldonio.atlassian.net/browse/DPL-293).

The use of an abstract base class (ABC) utilises a standard library feature and improves the "grep-ability" of abstract methods.

I've also refactored the handling of unknown auth types to a function to:
0. avoid duplication, and
1. ensure more informative errors - rather than being told something went wrong, the user can see _what_ auth method was actually requested