### PR TITLE
Using same verify_ssl config for auth and api requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__
 .idea
+.vscode

--- a/python/seldon_deploy_sdk/auth/openid.py
+++ b/python/seldon_deploy_sdk/auth/openid.py
@@ -52,6 +52,7 @@ class OIDCAuthenticator(Authenticator):
             client_secret=config.oidc_client_secret,
             server_metadata_url=server_metadata_url,
             access_token_params=access_token_params,
+            verify=config.verify_ssl
         )
         self._app.load_server_metadata()
 

--- a/python/seldon_deploy_sdk/auth/openid.py
+++ b/python/seldon_deploy_sdk/auth/openid.py
@@ -1,6 +1,6 @@
 from urllib.parse import urlencode
 import logging
-
+import os
 from authlib.integrations.base_client import FrameworkIntegration, RemoteApp
 from authlib.integrations.requests_client import OAuth2Session
 
@@ -28,6 +28,9 @@ class OIDCAuthenticator(Authenticator):
     def __init__(self, config: Configuration):
         super().__init__(config)
 
+        if not config.verify_ssl:
+            os.environ["CURL_CA_BUNDLE"] = ""
+
         if config.oidc_server is None:
             raise ValueError("config.oidc_server is required")
         if config.oidc_client_id is None:
@@ -52,7 +55,6 @@ class OIDCAuthenticator(Authenticator):
             client_secret=config.oidc_client_secret,
             server_metadata_url=server_metadata_url,
             access_token_params=access_token_params,
-            verify=config.verify_ssl
         )
         self._app.load_server_metadata()
 

--- a/python/seldon_deploy_sdk/auth/openid.py
+++ b/python/seldon_deploy_sdk/auth/openid.py
@@ -3,7 +3,7 @@ import logging
 import os
 from authlib.integrations.base_client import FrameworkIntegration, RemoteApp
 from authlib.integrations.requests_client import OAuth2Session
-
+import urllib3
 from seldon_deploy_sdk.configuration import Configuration
 
 from .base import (
@@ -30,6 +30,7 @@ class OIDCAuthenticator(Authenticator):
 
         if not config.verify_ssl:
             os.environ["CURL_CA_BUNDLE"] = ""
+            urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
         if config.oidc_server is None:
             raise ValueError("config.oidc_server is required")

--- a/templates/python/auth/openid.py
+++ b/templates/python/auth/openid.py
@@ -52,6 +52,7 @@ class OIDCAuthenticator(Authenticator):
             client_secret=config.oidc_client_secret,
             server_metadata_url=server_metadata_url,
             access_token_params=access_token_params,
+            verify=config.verify_ssl
         )
         self._app.load_server_metadata()
 

--- a/templates/python/auth/openid.py
+++ b/templates/python/auth/openid.py
@@ -1,6 +1,6 @@
 from urllib.parse import urlencode
 import logging
-
+import os
 from authlib.integrations.base_client import FrameworkIntegration, RemoteApp
 from authlib.integrations.requests_client import OAuth2Session
 
@@ -28,6 +28,9 @@ class OIDCAuthenticator(Authenticator):
     def __init__(self, config: Configuration):
         super().__init__(config)
 
+        if not config.verify_ssl:
+            os.environ["CURL_CA_BUNDLE"] = ""
+
         if config.oidc_server is None:
             raise ValueError("config.oidc_server is required")
         if config.oidc_client_id is None:
@@ -52,7 +55,6 @@ class OIDCAuthenticator(Authenticator):
             client_secret=config.oidc_client_secret,
             server_metadata_url=server_metadata_url,
             access_token_params=access_token_params,
-            verify=config.verify_ssl
         )
         self._app.load_server_metadata()
 

--- a/templates/python/auth/openid.py
+++ b/templates/python/auth/openid.py
@@ -3,7 +3,7 @@ import logging
 import os
 from authlib.integrations.base_client import FrameworkIntegration, RemoteApp
 from authlib.integrations.requests_client import OAuth2Session
-
+import urllib3
 from seldon_deploy_sdk.configuration import Configuration
 
 from .base import (
@@ -30,6 +30,7 @@ class OIDCAuthenticator(Authenticator):
 
         if not config.verify_ssl:
             os.environ["CURL_CA_BUNDLE"] = ""
+            urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
         if config.oidc_server is None:
             raise ValueError("config.oidc_server is required")


### PR DESCRIPTION
https://seldonio.atlassian.net/browse/DPL-852
Also the sdk is regenerated from the new template.