### PR TITLE
chore(examples): Use new field and make examples consistent

### DIFF
--- a/examples/feature_distributions_demo.ipynb
+++ b/examples/feature_distributions_demo.ipynb
@@ -1,14 +1,34 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Feature distributions from income classifier demo\n",
+    "\n",
+    "You'll need to have setup the pipeline for the income classifier and done some requests."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## API Configuration"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
     "from seldon_deploy_sdk.rest import ApiException\n",
-    "\n",
-    "from seldon_deploy_sdk import MonitorApi,DeploymentFeatureData, Configuration, ApiClient\n",
+    "from seldon_deploy_sdk import (\n",
+    "    MonitorApi,\n",
+    "    DeploymentFeatureData,\n",
+    "    Configuration,\n",
+    "    ApiClient,\n",
+    ")\n",
     "from seldon_deploy_sdk.auth import OIDCAuthenticator"
    ]
   },
@@ -16,27 +36,45 @@
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "DEPRECATED!! Future versions of seldon_deploy_sdk will ignore the access_token field. Use the id_token field instead.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "INGRESS = \"http://localhost:8000\"\n",
+    "# For local testing use\n",
+    "INGRESS = \"http://localhost:8080\"\n",
     "\n",
+    "# For production usecase set this to your ingress\n",
+    "# for example if your SD URL is http://xxx.yyy.zzz.xyz/seldon-deploy/api/v1alpha1 set\n",
+    "# INGRESS = \"http://xxx.yyy.zzz.xyz\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "config = Configuration()\n",
-    "config.host = f\"{INGRESS}/seldon-deploy/api/v1alpha1\"\n",
-    "config.verify_ssl = False\n",
+    "config.host = f\"{INGRESS}/seldon-deploy/api/v1alpha1\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# auth if needed\n",
     "config.oidc_server = f\"{INGRESS}/auth/realms/deploy-realm\"\n",
     "config.oidc_client_id = \"sd-api\"\n",
     "config.oidc_client_secret = \"sd-api-secret\"\n",
     "config.auth_method = \"client_credentials\"\n",
+    "\n",
+    "# Alternativey set instead of the \"client_credentials\" flow\n",
+    "# config.username = \"admin@seldon.io\"\n",
+    "# config.password = \"12341234\"\n",
+    "# config.auth_method = \"password\"\n",
+    "\n",
     "auth = OIDCAuthenticator(config)\n",
-    "config.access_token = auth.authenticate()\n"
+    "config.id_token = auth.authenticate()"
    ]
   },
   {
@@ -50,23 +88,32 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Request feature distributions"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
-    "deployment_name=\"income-classifier\"\n",
-    "deployment_namespace=\"seldon\"\n",
+    "deployment_name = \"income-classifier\"\n",
+    "deployment_namespace = \"seldon\"\n",
     "feature_data = DeploymentFeatureData(\n",
     "    feature=\"Education\",\n",
     "    interaction=\"request\",\n",
     "    aggregate_over_time=True,\n",
     "    deployment_endpoint=\"default\",\n",
-    "    deployment_node=\"income-classifier-container\"\n",
+    "    deployment_node=\"income-classifier-container\",\n",
     ")\n",
     "try:\n",
     "    # Get feature distributions\n",
-    "    api_response = api_instance.seldon_deployment_feature_distributions(deployment_name,deployment_namespace,feature_data)\n",
+    "    api_response = api_instance.seldon_deployment_feature_distributions(\n",
+    "        deployment_name, deployment_namespace, feature_data\n",
+    "    )\n",
     "except ApiException as e:\n",
     "    print(f\"Couldn't fetch distributions: {e}\")"
    ]
@@ -102,9 +149,10 @@
    ],
    "source": [
     "import matplotlib.pyplot as plt\n",
+    "\n",
     "fig = plt.figure()\n",
-    "ax = fig.add_axes([0,0,1,1])\n",
-    "ax.bar(groups,counts)\n",
+    "ax = fig.add_axes([0, 0, 1, 1])\n",
+    "ax.bar(groups, counts)\n",
     "plt.show()"
    ]
   }

--- a/examples/metadata_demo.ipynb
+++ b/examples/metadata_demo.ipynb
@@ -23,7 +23,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Api Configuration"
+    "## API Configuration"
    ]
   },
   {
@@ -33,7 +33,6 @@
    "outputs": [],
    "source": [
     "from seldon_deploy_sdk.rest import ApiException\n",
-    "\n",
     "from seldon_deploy_sdk import V1Model, ModelMetadataServiceApi, Configuration, ApiClient\n",
     "from seldon_deploy_sdk.auth import OIDCAuthenticator"
    ]
@@ -90,7 +89,7 @@
     "# config.auth_method = \"password\"\n",
     "\n",
     "auth = OIDCAuthenticator(config)\n",
-    "config.access_token = auth.authenticate()"
+    "config.id_token = auth.authenticate()"
    ]
   },
   {
@@ -324,7 +323,9 @@
     "\n",
     "try:\n",
     "    # List Model Metadata entries.\n",
-    "    api_response = api_instance.model_metadata_service_list_model_metadata(name=\"beta\", tags={\"author\": \"Jon\"})\n",
+    "    api_response = api_instance.model_metadata_service_list_model_metadata(\n",
+    "        name=\"beta\", tags={\"author\": \"Jon\"}\n",
+    "    )\n",
     "    print(\"Filter by name=beta\")\n",
     "    pprint(api_response)\n",
     "except ApiException as e:\n",
@@ -382,7 +383,9 @@
     "\n",
     "try:\n",
     "    # List Model Metadata entries.\n",
-    "    api_response = api_instance.model_metadata_service_list_model_metadata(tags={\"author\": \"Bob\"})\n",
+    "    api_response = api_instance.model_metadata_service_list_model_metadata(\n",
+    "        tags={\"author\": \"Bob\"}\n",
+    "    )\n",
     "    print(\"Filter by name=beta\")\n",
     "    pprint(api_response)\n",
     "except ApiException as e:\n",
@@ -438,7 +441,9 @@
    "source": [
     "try:\n",
     "    # Get Model Metadata entries.\n",
-    "    api_response = api_instance.model_metadata_service_list_model_metadata(uri=\"gs://test-model-alpha-v1.0.0\")\n",
+    "    api_response = api_instance.model_metadata_service_list_model_metadata(\n",
+    "        uri=\"gs://test-model-alpha-v1.0.0\"\n",
+    "    )\n",
     "    print(\"Before update:\")\n",
     "    pprint(api_response)\n",
     "except ApiException as e:\n",
@@ -464,7 +469,7 @@
     "    pprint(api_response)\n",
     "except ApiException as e:\n",
     "    print(f\"Failed to call API: {json.loads(e.body)['message']}\")\n",
-    "    \n",
+    "\n",
     "try:\n",
     "    # List Model Metadata entries.\n",
     "    api_response = api_instance.model_metadata_service_list_model_metadata(\n",
@@ -542,8 +547,7 @@
     "try:\n",
     "    # List Runtime Metadata for all deployments associated with a model.\n",
     "    api_response = api_instance.model_metadata_service_list_runtime_metadata_for_model(\n",
-    "        model_uri=\"gs://seldon-models/sklearn/iris\", \n",
-    "        deployment_status=\"Running\"\n",
+    "        model_uri=\"gs://seldon-models/sklearn/iris\", deployment_status=\"Running\"\n",
     "    )\n",
     "    pprint(api_response)\n",
     "except ApiException as e:\n",
@@ -595,8 +599,7 @@
     "try:\n",
     "    # List Runtime Metadata for all deployments associated with a model.\n",
     "    api_response = api_instance.model_metadata_service_list_runtime_metadata_for_model(\n",
-    "        deployment_name=\"iris\", \n",
-    "        deployment_namespace=\"seldon\"\n",
+    "        deployment_name=\"iris\", deployment_namespace=\"seldon\"\n",
     "    )\n",
     "    pprint(api_response)\n",
     "except ApiException as e:\n",

--- a/examples/token-refresh-password-grant.py
+++ b/examples/token-refresh-password-grant.py
@@ -32,7 +32,7 @@ config.auth_method = 'password_grant'
 
 auth = OIDCAuthenticator(config)
 
-config.access_token = auth.authenticate()
+config.id_token = auth.authenticate()
 
 print(config.access_token)
 


### PR DESCRIPTION
Some small changes to the examples for a better experience.

**Changes**

- Consistent sections for API setup
- Auto-formatting
- Use of `id_token` over `access_token`