### PR TITLE
fix(examples): Don't verify SSL

### DIFF
--- a/examples/feature_distributions_demo.ipynb
+++ b/examples/feature_distributions_demo.ipynb
@@ -53,7 +53,8 @@
    "outputs": [],
    "source": [
     "config = Configuration()\n",
-    "config.host = f\"{INGRESS}/seldon-deploy/api/v1alpha1\""
+    "config.host = f\"{INGRESS}/seldon-deploy/api/v1alpha1\"\n",
+    "config.verify_ssl = False"
    ]
   },
   {

--- a/examples/metadata_demo.ipynb
+++ b/examples/metadata_demo.ipynb
@@ -68,7 +68,8 @@
    "outputs": [],
    "source": [
     "config = Configuration()\n",
-    "config.host = f\"{INGRESS}/seldon-deploy/api/v1alpha1\""
+    "config.host = f\"{INGRESS}/seldon-deploy/api/v1alpha1\"\n",
+    "config.verify_ssl = False"
    ]
   },
   {

--- a/examples/token-refresh-password-grant.py
+++ b/examples/token-refresh-password-grant.py
@@ -21,6 +21,7 @@ def call_env():
 
 config = Configuration()
 config.host = "http://x.x.x.x/seldon-deploy/api/v1alpha1"
+config.verify_ssl = False
 config.oidc_client_id = client_id
 config.oidc_server = "http://x.x.x.x/auth/realms/deploy-realm"
 config.username = username


### PR DESCRIPTION
One of these was inadvertently removed in #61. I've added it back and also set the config to be the same in all examples.